### PR TITLE
Fix possible fatal error while getting public IP

### DIFF
--- a/class-get-public-ip.php
+++ b/class-get-public-ip.php
@@ -59,14 +59,18 @@ class UBP_Get_Public_IP {
 		);
 
 		$response = wp_remote_get( $url, $query_args );
-		$body = strip_tags($response['body']);
+		
+		if ( ! is_wp_error( $response ) ) {
+			$body = strip_tags($response['body']);
 
-		preg_match_all( $this->ip_pattern, $body, $matches );
+			preg_match_all( $this->ip_pattern, $body, $matches );
 
-		if ( !empty($matches[0][$index] ) ) { return $matches[0][$index]; }
+			return !empty( $matches[0][$index] )
+				? $matches[0][$index]
+				: false;
+		}
 
 		return false;
-
 	}
 
 }


### PR DESCRIPTION
This simple pull request fixes a possible fatal error that can occur if the http request made when trying to lookup the public IP fails.

The error I was receiving was

```
PHP Fatal error:  Cannot use object of type WP_Error as array in 
.../plugins/uploads-by-proxy/class-get-public-ip.php on line 62
```

The `$response` was coming back as a WP_Error `http_request_failed: couldn't connect to host at hostnametoip.com:80`.
