### PR TITLE
Don't use ABSPATH.

### DIFF
--- a/class-404-template.php
+++ b/class-404-template.php
@@ -107,7 +107,7 @@ class UBP_404_Template {
 	 */
 	public function uploads_basedir() {
 		$uploads = wp_upload_dir();
-		return str_replace( ABSPATH, '', $uploads['basedir'] );
+		return parse_url( $uploads['baseurl'], PHP_URL_PATH );
 	}
 
 	public function get_siteurl() {


### PR DESCRIPTION
Our local environment puts the base wordpress install in a separate directory from the site directory. This is not an uncommon setup, allowing a single base install to be reused across multiple sites. This results in ABSPATH pointing to the base wordpress directory and not the site directory. This makes it unreliable to depend on this variable to get the relative path to the uploads directory.

This removes the use of this variable and relies on the path from the URL which is more likely to give an accurate path.