### PR TITLE
Fix uploads basedir for downloading media.

### DIFF
--- a/class-404-template.php
+++ b/class-404-template.php
@@ -43,14 +43,12 @@ class UBP_404_Template {
 		global $wp_filesystem; WP_Filesystem();
 
 		$u = wp_upload_dir();
-		$basedir = $u['basedir'];
 
-		$remove = str_replace( get_option( 'siteurl' ), '', $u['baseurl'] );
-		$basedir = str_replace( $remove, '', $basedir );
+		$basedir = str_replace( $this->uploads_basedir(), '', $u['basedir'] );
 		$abspath = $basedir . $this->get_local_path();
 		$dir = dirname( $abspath );
 
-		if ( !is_dir( $dir ) && !wp_mkdir_p( $dir ) ) { 
+		if ( !is_dir( $dir ) && !wp_mkdir_p( $dir ) ) {
 			$this->display_and_exit( "Please check permissions. Could not create directory $dir" );
 		}
 


### PR DESCRIPTION
Our local environment puts the base wordpress install in a separate directory from the site directory. This is not an uncommon setup, allowing a single base install to be reused across multiple sites.

Due to this the original code would get the base wordpress directory and end up saving files into a wp-content directory in there, rather than into the site's uploads directory.

This fix ensures that it uses the site's actual uploads directory. This fix may depend on the ABSPATH fix.