### PR TITLE
Fix path getting mangled from name collision.

### DIFF
--- a/class-404-template.php
+++ b/class-404-template.php
@@ -155,11 +155,11 @@ class UBP_404_Template {
 		}
 
 		// If local install is in a subdirectory, modify path to request from WordPress root
-		$local_wordpress_path = parse_url( get_site_url(), PHP_URL_PATH );
+		$local_wordpress_path = parse_url( get_site_url(), PHP_URL_PATH ) . '/';
 		$requested_path = parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 		if (substr($requested_path, 0, strlen($local_wordpress_path)) == $local_wordpress_path) {
-		    $requested_path = substr($requested_path, strlen($local_wordpress_path), strlen($requested_path));
-		} 
+		    $requested_path = substr($requested_path, strlen($local_wordpress_path)-1, strlen($requested_path));
+		}
 
 		$this->local_path = $requested_path;
 


### PR DESCRIPTION
Our local environment puts the base wordpress install in a separate directory from the site directory. This is not an uncommon setup, allowing a single base install to be reused across multiple sites.

In our case, the wordpress install appears in the path /wp/ while the site content is at the root, and not under this subdirectory.

This results in the code stripping /wp from the content path, originally /wp-content/uploads being stripped to -content/uploads, which obviously breaks the URLs.

This solution simply adds the trailing slash to the path that it tries to strip, checking for /wp/ rather than just /wp. This making the code a bit more robust.