### PR TITLE
Removed loopup to baremetal

### DIFF
--- a/class-get-public-ip.php
+++ b/class-get-public-ip.php
@@ -23,7 +23,6 @@ class UBP_Get_Public_IP {
 			$custom_args = apply_filters('ubp_ip_args', array() );
 
 			if ( $custom_url ) $ip = $this->get_ip( $custom_url, $custom_args );
-			if ( !$ip ) $ip = $this->get_ip( "http://baremetal.com/cgi-bin/dnsip?target=$domain" );
 			if ( !$ip ) $ip = $this->get_ip( 'http://hostnametoip.com/', array( 'index'=>1, 'method' => 'POST', 'referer'=>'http://hostnametoip.com/', 'body' => 'conversion=1&addr='.$domain ) );
 			if ( !$ip ) $ip = $this->get_ip( "http://aruljohn.com/cgi-bin/hostname2ip.pl?host=$domain", array( 'referer'=>'http://aruljohn.com/hostname2ip.html' ) );
 


### PR DESCRIPTION
Baremetal has stopped allowing lookups. Stop hitting them up.

Was seeing why the lookup to hostnametoip lookup was failing on my local code downloaded from https://wordpress.org/plugins/uploads-by-proxy/ recently and wrote a fix. When I went to submit my changes I found that they are already fixed here - why not release this long fixed change to wordpress.org?