### PR TITLE
Fixed errors in get public IP

### DIFF
--- a/class-get-public-ip.php
+++ b/class-get-public-ip.php
@@ -44,7 +44,7 @@ class UBP_Get_Public_IP {
 	public function get_ip( $url, $args=array() ) {
 		$defaults = array( 
 			'method' => 'GET',
-			'referer'=> $domain,
+			'referer'=> $this->domain,
 			'body' => '',
 			'index' => 0,
 		);
@@ -58,9 +58,9 @@ class UBP_Get_Public_IP {
 		);
 
 		$response = wp_remote_get( $url, $query_args );
-		
+
 		if ( ! is_wp_error( $response ) ) {
-			$body = strip_tags($response['body']);
+			$body = strip_tags($response->body);
 
 			preg_match_all( $this->ip_pattern, $body, $matches );
 


### PR DESCRIPTION
Got the following errors on a particular host today:

[24-Jun-2016 17:36:48 UTC] PHP Notice: Undefined variable: domain in /home/tpglight/public_html/staging/wp-content/plugins/uploads-by-proxy/class-get-public-ip.php on line 48
[24-Jun-2016 17:36:49 UTC] PHP Notice: Undefined variable: domain in /home/tpglight/public_html/staging/wp-content/plugins/uploads-by-proxy/class-get-public-ip.php on line 48
[24-Jun-2016 17:36:54 UTC] PHP Fatal error: Cannot use object of type WP_Error as array in /home/tpglight/public_html/staging/wp-content/plugins/uploads-by-proxy/class-get-public-ip.php on line 62

